### PR TITLE
Fixed Text overflow on certain devices by adding ellipsis in GridBackgroundScreen

### DIFF
--- a/app/src/main/java/com/naulian/composable/screens/background/GridBackgroundScreenUI.kt
+++ b/app/src/main/java/com/naulian/composable/screens/background/GridBackgroundScreenUI.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -74,7 +75,8 @@ fun GridBackgroundScreenUI(onBack: () -> Unit = {}) {
                         )
                         .padding(20.dp)
                 ) {
-                    Text(text = Lorem.short, fontSize = 64.sp, color = Gray)
+                    // Add Ellipsis for preventing overflow on some devices
+                    Text(text = Lorem.short, fontSize = 64.sp, color = Gray, overflow = TextOverflow.Ellipsis)
                 }
 
                 CodeBlock(


### PR DESCRIPTION
![overflow fixed on device](https://github.com/user-attachments/assets/05c91404-0b5c-422d-9f8d-24c74e9a1daf)
![Overflow on device](https://github.com/user-attachments/assets/e31a757b-4024-4ede-bd63-4fea6e8eba46)
<img width="1344" height="2992" alt="in pixel 9 pro xl" src="https://github.com/user-attachments/assets/b2d9dd56-0956-488c-a6ee-ad5e4f899be6" />

We can also just adjust LineHeight instead of ellipsis, what do u say
<img width="1919" height="1079" alt="ui fix" src="https://github.com/user-attachments/assets/89e2773c-9795-4cdb-858b-1819d0c5096c" />
