### PR TITLE
feat: add cafe receipt shape

### DIFF
--- a/app/src/main/java/com/naulian/composable/AppNavHost.kt
+++ b/app/src/main/java/com/naulian/composable/AppNavHost.kt
@@ -24,6 +24,7 @@ import com.naulian.composable.icc.parallaxCards.ParallaxCardStackScreen
 import com.naulian.composable.icc.rating.RatingStarsScreen
 import com.naulian.composable.icc.step_progress.ProgressScreen
 import com.naulian.composable.scc.StaticCCScreen
+import com.naulian.composable.scc.cafeReceipt.CafeReceiptScreen
 import com.naulian.composable.scc.cornered_box.CorneredBoxScreen
 import com.naulian.composable.scc.depthCards.DepthCardScreen
 import com.naulian.composable.scc.glass.GlassCardScreen
@@ -128,6 +129,10 @@ fun AppNavHost() {
 
             composable<Screen.DepthCard> {
                 DepthCardScreen()
+            }
+
+            composable<Screen.CafeReceipt> {
+                CafeReceiptScreen()
             }
 
 

--- a/core/src/main/java/com/naulian/composable/core/Screen.kt
+++ b/core/src/main/java/com/naulian/composable/core/Screen.kt
@@ -68,4 +68,7 @@ sealed interface Screen {
 
     @Serializable
     data object Clock : Screen
+
+    @Serializable
+    data object CafeReceipt : Screen
 }

--- a/scc/src/main/java/com/naulian/composable/scc/StaticCCScreenUI.kt
+++ b/scc/src/main/java/com/naulian/composable/scc/StaticCCScreenUI.kt
@@ -54,6 +54,11 @@ private val sccItemList = listOf(
         name = "Depth Card",
         contributor = "Romit Sharma",
         route = Screen.DepthCard
+    ),
+    StaticCCItem(
+        name = "Cafe Receipt",
+        contributor = "Prashant Panwar",
+        route = Screen.CafeReceipt
     )
 )
 

--- a/scc/src/main/java/com/naulian/composable/scc/cafeReceipt/WaveReceiptShape.kt
+++ b/scc/src/main/java/com/naulian/composable/scc/cafeReceipt/WaveReceiptShape.kt
@@ -1,0 +1,151 @@
+
+// WaveReceiptShape.kt
+// A Jetpack Compose Shape that draws a receipt with sinusoid (wave-like cut) edges
+// at the top and/or bottom, similar to typical printed receipt designs.
+package com.naulian.composable.scc.cafeReceipt
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.min
+
+/**
+ * WaveReceiptShape — top and bottom sinusoidal edges that START and END on a crest.
+ *
+ * amplitude: vertical distance from crest to trough
+ * cycles: number of full cycles across usable width (>= 1)
+ * cornerRadius: left/right corner radius
+ * samplingStepPx: sampling resolution in px
+ */
+class WaveReceiptShape(
+    private val amplitude: Float = 12f,
+    private val cycles: Int = 10,
+    private val cornerRadius: Float = 12f,
+    private val samplingStepPx: Int = 1
+) : Shape {
+
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val w = size.width
+        val h = size.height
+
+        // Guard rails
+        val cr = cornerRadius.coerceAtMost(min(w, h) / 2f)
+        val usableLeft = cr
+        val usableRight = w - cr
+        // width available for the wave (excludes corner radii)
+        val usableW = maxOf(0.0001f, usableRight - usableLeft)
+
+        val k = maxOf(1, cycles) // number of cycles
+        val wavelength = usableW / k
+
+        // Calculate total number of sample points
+        val pointsPerCycle = maxOf(3, (wavelength / samplingStepPx).toInt())
+        // total samples across the whole usable width
+        val totalPoints = pointsPerCycle * k
+
+        // sinusoid
+        fun topYAt(x: Float): Float {
+            val t = (x - usableLeft) / usableW // normalized [0..1]
+            // angle used by cosine so phase=0 at left crest and phase=2πk at right crest
+            val phase = 2.0 * PI * k * t
+            return (amplitude * (1 - cos(phase)) / 2).toFloat()
+        }
+
+        fun bottomYAt(x: Float): Float = h - topYAt(x) // top mirror
+
+        val path = Path()
+
+        // Start at top-left corner
+        path.moveTo(0f, cr)
+        if (cr > 0f) {
+            path.quadraticTo(0f, 0f, usableLeft, 0f)
+        } else {
+            path.lineTo(usableLeft, 0f)
+        }
+
+        // Top wave
+        for (i in 0..totalPoints) {
+            val x = usableLeft + i * usableW / totalPoints
+            path.lineTo(x, topYAt(x))
+        }
+
+        // Top-right corner
+        if (cr > 0f) {
+            path.quadraticTo(w, 0f, w, cr)
+        } else {
+            path.lineTo(w, cr)
+        }
+
+        // Right edge down
+        path.lineTo(w, h - cr)
+
+        // Bottom-right corner
+        if (cr > 0f) {
+            path.quadraticTo(w, h, w - cr, h)
+        } else {
+            path.lineTo(w - cr, h)
+        }
+
+        // --- Bottom wave (reverse) ---
+        for (i in totalPoints downTo 0) {
+            val x = usableLeft + i * usableW / totalPoints
+            path.lineTo(x, bottomYAt(x))
+        }
+
+        // Bottom-left corner
+        if (cr > 0f) {
+            path.quadraticTo(0f, h, 0f, h - cr)
+        } else {
+            path.lineTo(0f, h - cr)
+        }
+
+        // Close path
+        path.lineTo(0f, cr)
+        path.close()
+
+        return Outline.Generic(path)
+    }
+}
+
+@Preview
+@Composable
+fun ReceiptShapePreview() {
+    MaterialTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = Color.Gray)
+                .padding(20.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .height(600.dp)
+                    .fillMaxWidth()
+                    .align(Alignment.Center)
+                    .background(Color.White, shape = WaveReceiptShape(cycles = 20))
+            )
+        }
+    }
+}

--- a/scc/src/main/res/drawable/coffee.xml
+++ b/scc/src/main/res/drawable/coffee.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,720q-117,0 -198.5,-81.5T160,440v-240q0,-33 23.5,-56.5T240,120h500q58,0 99,41t41,99q0,58 -41,99t-99,41h-20v40q0,117 -81.5,198.5T440,720ZM240,320h400v-120L240,200v120ZM440,640q83,0 141.5,-58.5T640,440v-40L240,400v40q0,83 58.5,141.5T440,640ZM720,320h20q25,0 42.5,-17.5T800,260q0,-25 -17.5,-42.5T740,200h-20v120ZM160,840v-80h640v80L160,840ZM440,400Z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
Adds a cafe receipt screen with wave cutout on both top and bottom

<img width="287" height="518" alt="Screenshot 2025-09-25 011438" src="https://github.com/user-attachments/assets/4ff03d54-7343-4c5b-9ef2-10d67555d6a3" />
