### PR TITLE
Add cylindrical buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,30 @@
 
 **An open-source Android app showcasing Jetpack Compose UI components and interactions for learning and inspiration.**
 
-https://github.com/user-attachments/assets/a940ce12-e9d1-4fd1-b6dd-c759088a3a0a
-
-<img src="screenshots/image1.webp" alt="screenshot" width="240"></img>
 <img src="screenshots/image2.webp" alt="screenshot" width="240"></img>
+<img width="240" alt="screenshot" src="https://github.com/user-attachments/assets/03d1e201-3c06-4cc7-9427-a1a9d1c8d9c0" />
+<img width="240" alt="screenshot" src="https://github.com/user-attachments/assets/3d1ce17c-6c76-490a-838a-7484a816813f" />
+<img width="240" alt="screenshot" src="https://github.com/user-attachments/assets/8ea8b57b-b16f-4ab9-bddb-6bbffecc85f3" />
+<img width="240" alt="screenshot" src="https://github.com/user-attachments/assets/31cea918-f43a-4879-ae8d-907c36d84338" />
+<img width="240" alt="screenshot" src="https://github.com/user-attachments/assets/699e268b-0c5a-4a76-bb6d-2ca1dd99e420" />
+
+https://github.com/user-attachments/assets/24df34d1-fe36-479f-bf41-eb7fd524e740
+
+https://github.com/user-attachments/assets/cce1dac1-6726-435e-b5e6-3f73c511569c
+
+https://github.com/user-attachments/assets/ca1b1d4f-a4e6-451c-b4a2-916338214c79
+
+https://github.com/user-attachments/assets/dd7fa015-5807-4c8a-be56-b061537bc978
+
+https://github.com/user-attachments/assets/def2e67d-89d1-498d-9ce5-ca715f9c2f73
+
+https://github.com/user-attachments/assets/2bfdb6a2-457c-4bb8-8208-c94c403723bc
+
+https://github.com/user-attachments/assets/4b0d2eaa-b25e-46db-b98e-f835178f0e2f
+
+https://github.com/user-attachments/assets/62abab0c-cdf3-4021-86d8-d7a21832c112
+
+https://github.com/user-attachments/assets/de8af136-b6b3-4080-a671-fb4405475df5
 
 ---
 

--- a/app/src/main/java/com/naulian/composable/AppNavHost.kt
+++ b/app/src/main/java/com/naulian/composable/AppNavHost.kt
@@ -24,6 +24,7 @@ import com.naulian.composable.icc.parallaxCards.ParallaxCardStackScreen
 import com.naulian.composable.icc.rating.RatingStarsScreen
 import com.naulian.composable.icc.step_progress.ProgressScreen
 import com.naulian.composable.scc.StaticCCScreen
+import com.naulian.composable.scc.cafeReceipt.CafeReceiptScreen
 import com.naulian.composable.scc.cornered_box.CorneredBoxScreen
 import com.naulian.composable.scc.depthCards.DepthCardScreen
 import com.naulian.composable.scc.glass.GlassCardScreen
@@ -128,6 +129,10 @@ fun AppNavHost() {
 
             composable<Screen.DepthCard> {
                 DepthCardScreen()
+            }
+
+            composable<Screen.CafeReceipt> {
+                CafeReceiptScreen()
             }
 
 

--- a/app/src/main/java/com/naulian/composable/AppNavHost.kt
+++ b/app/src/main/java/com/naulian/composable/AppNavHost.kt
@@ -20,11 +20,12 @@ import com.naulian.composable.home.HomeScreen
 import com.naulian.composable.icc.InteractiveCCScreen
 import com.naulian.composable.icc.calenderTopBar.CalenderTopBarScreen
 import com.naulian.composable.icc.cardCrousel.BetterCarouselScreen
+import com.naulian.composable.icc.cylindricalButton.CylindricalButtonsScreen
 import com.naulian.composable.icc.parallaxCards.ParallaxCardStackScreen
 import com.naulian.composable.icc.rating.RatingStarsScreen
 import com.naulian.composable.icc.step_progress.ProgressScreen
 import com.naulian.composable.scc.StaticCCScreen
-import com.naulian.composable.scc.cafeReceipt.CafeReceiptScreen
+//import com.naulian.composable.scc.cafeReceipt.CafeReceiptScreen
 import com.naulian.composable.scc.cornered_box.CorneredBoxScreen
 import com.naulian.composable.scc.depthCards.DepthCardScreen
 import com.naulian.composable.scc.glass.GlassCardScreen
@@ -66,89 +67,76 @@ fun AppNavHost() {
                 )
             },
         ) {
+            // General
             composable<Screen.Home> {
                 HomeScreen()
             }
 
+            // Static Components
             composable<Screen.StaticCC> {
                 StaticCCScreen()
             }
-
-            composable<Screen.InteractiveCC> {
-                InteractiveCCScreen()
-            }
-
-            composable<Screen.AnimatedCC> {
-                AnimatedCCScreen()
-            }
-
             composable<Screen.Neumorphism> {
                 NeumorphicScreen()
             }
-
             composable<Screen.GridBackground> {
                 GridBackgroundScreen()
             }
-
             composable<Screen.CorneredBox> {
                 CorneredBoxScreen()
             }
-
-            composable<Screen.RatingStars> {
-                RatingStarsScreen()
-            }
-
-            composable<Screen.ParallaxCardStack> {
-                ParallaxCardStackScreen()
-            }
-
-            composable<Screen.BetterCarousel> {
-                BetterCarouselScreen()
-            }
-
-            composable<Screen.StepsProgress> {
-                ProgressScreen()
-            }
-
-            composable<Screen.BottomBar> {
-                BottomBarScreen()
-            }
-
-            composable<Screen.CalenderTopBar> {
-                CalenderTopBarScreen()
-            }
-
-
             composable<Screen.GlassCard> {
                 GlassCardScreen()
             }
-
             composable<Screen.MovieTicket> {
                 MovieTicketScreen()
             }
-
             composable<Screen.DepthCard> {
                 DepthCardScreen()
             }
+//            composable<Screen.CafeReceipt> {
+//                CafeReceiptScreen()
+//            }
 
-            composable<Screen.CafeReceipt> {
-                CafeReceiptScreen()
+            // Interactive Components
+            composable<Screen.InteractiveCC> {
+                InteractiveCCScreen()
+            }
+            composable<Screen.RatingStars> {
+                RatingStarsScreen()
+            }
+            composable<Screen.ParallaxCardStack> {
+                ParallaxCardStackScreen()
+            }
+            composable<Screen.BetterCarousel> {
+                BetterCarouselScreen()
+            }
+            composable<Screen.StepsProgress> {
+                ProgressScreen()
+            }
+            composable<Screen.BottomBar> {
+                BottomBarScreen()
+            }
+            composable<Screen.CalenderTopBar> {
+                CalenderTopBarScreen()
+            }
+            composable<Screen.CylindricalButtons> {
+                CylindricalButtonsScreen()
             }
 
-
-            //Animated Composable Components
+            // Animated Components
+            composable<Screen.AnimatedCC> {
+                AnimatedCCScreen()
+            }
             composable<Screen.TypingText> {
                 TypingTextScreen()
             }
-
             composable<Screen.PulseHeart> {
                 PulseScreen()
             }
-
             composable<Screen.GlitchEffect> {
                 GlitchScreen()
             }
-
             composable<Screen.Clock> {
                 ClockScreen()
             }

--- a/core/src/main/java/com/naulian/composable/core/Screen.kt
+++ b/core/src/main/java/com/naulian/composable/core/Screen.kt
@@ -5,16 +5,11 @@ import kotlinx.serialization.Serializable
 sealed interface Screen {
 
     @Serializable
-    data object Home : Screen
+    data object Home : Screen // General
 
+    // Static Components
     @Serializable
     data object StaticCC : Screen
-
-    @Serializable
-    data object InteractiveCC : Screen
-
-    @Serializable
-    data object AnimatedCC : Screen
 
     @Serializable
     data object Neumorphism : Screen
@@ -26,10 +21,20 @@ sealed interface Screen {
     data object CorneredBox : Screen
 
     @Serializable
-    data object RatingStars : Screen
+    data object GlassCard : Screen
 
     @Serializable
-    data object Second : Screen
+    data object MovieTicket : Screen
+
+    @Serializable
+    data object DepthCard: Screen
+
+    // Interactive Components
+    @Serializable
+    data object InteractiveCC : Screen
+
+    @Serializable
+    data object RatingStars : Screen
 
     @Serializable
     data object ParallaxCardStack : Screen
@@ -47,14 +52,14 @@ sealed interface Screen {
     data object CalenderTopBar : Screen
 
     @Serializable
-    data object GlassCard : Screen
+    data object CylindricalButtons: Screen
+
+    // Animated Components
+    @Serializable
+    data object AnimatedCC : Screen 
 
     @Serializable
-    data object MovieTicket : Screen
-
-    @Serializable
-    data object DepthCard: Screen
-
+    data object Second : Screen // Unsure, leaving as is for now
 
     //Animated
     @Serializable

--- a/core/src/main/java/com/naulian/composable/core/Screen.kt
+++ b/core/src/main/java/com/naulian/composable/core/Screen.kt
@@ -68,4 +68,7 @@ sealed interface Screen {
 
     @Serializable
     data object Clock : Screen
+
+    @Serializable
+    data object CafeReceipt : Screen
 }

--- a/icc/src/main/java/com/naulian/composable/icc/InteractiveCCScreenUI.kt
+++ b/icc/src/main/java/com/naulian/composable/icc/InteractiveCCScreenUI.kt
@@ -47,6 +47,11 @@ private val iccItemList = listOf(
         name = "Calender Top Bar",
         contributor = "Zain ul Abdin",
         route = Screen.CalenderTopBar
+    ),
+    InteractiveCCItem(
+        name = "Cylindrical 3D Buttons",
+        contributor = "Romit Sharma",
+        route = Screen.CylindricalButtons
     )
 )
 

--- a/icc/src/main/java/com/naulian/composable/icc/cylindricalButton/CylindricalButtonUI.kt
+++ b/icc/src/main/java/com/naulian/composable/icc/cylindricalButton/CylindricalButtonUI.kt
@@ -1,0 +1,349 @@
+package com.naulian.composable.icc.cylindricalButton
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateIntAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun IndustrialSquareButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    buttonSize: Int = 120,
+    cylinderDepth: Int = 20
+) {
+    var isPressed by remember { mutableStateOf(false) }
+
+    // Animation for pressing down the cylinder
+    val animatedDepth by animateIntAsState(
+        targetValue = if (isPressed) cylinderDepth / 3 else cylinderDepth,
+        animationSpec = tween(durationMillis = 150),
+        label = "depth"
+    )
+
+    val animatedButtonOffset by animateDpAsState(
+        targetValue = if (isPressed) (cylinderDepth * 2 / 3).dp else 0.dp,
+        animationSpec = tween(durationMillis = 150),
+        label = "buttonOffset"
+    )
+
+    Box(
+        modifier = modifier.size((buttonSize + cylinderDepth).dp),
+        contentAlignment = Alignment.TopCenter
+    ) {
+
+        // Square Cylinder Side Wall (the visible depth/body of the button)
+        Box(
+            modifier = Modifier
+                .offset(y = animatedButtonOffset)
+                .size(buttonSize.dp, (buttonSize + animatedDepth).dp)
+                .background(
+                    color = Color(0xFF972e25),
+                    shape = RoundedCornerShape(8.dp)
+                )
+        )
+
+        // Button Top Surface (the actual pressable square top)
+        Box(
+            modifier = Modifier
+                .offset(y = animatedButtonOffset)
+                .size(buttonSize.dp)
+                .background(
+                    color = Color(0xFFFF5757),
+                    shape = RoundedCornerShape(8.dp)
+                )
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onPress = {
+                            isPressed = true
+                            if(tryAwaitRelease())
+                            isPressed = false
+                        }
+                    )
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = text,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = (buttonSize / 8).sp
+            )
+        }
+    }
+}
+
+@Composable
+fun IndustrialCylinderButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    buttonSize: Int = 120,
+    cylinderDepth: Int = 20
+) {
+    var isPressed by remember { mutableStateOf(false) }
+
+    // Animation for pressing down the cylinder
+    val animatedDepth by animateIntAsState(
+        targetValue = if (isPressed) cylinderDepth / 3 else cylinderDepth,
+        animationSpec = tween(durationMillis = 150),
+        label = "depth"
+    )
+
+    val animatedButtonOffset by animateDpAsState(
+        targetValue = if (isPressed) (cylinderDepth * 2 / 3).dp else 0.dp,
+        animationSpec = tween(durationMillis = 150),
+        label = "buttonOffset"
+    )
+
+    Box(
+        modifier = modifier.size((buttonSize + cylinderDepth).dp),
+        contentAlignment = Alignment.TopCenter
+    ) {
+
+        // Cylinder Side Wall (the visible depth/body of the button)
+        Box(
+            modifier = Modifier
+                .offset(y = animatedButtonOffset)
+                .size(buttonSize.dp, (buttonSize + animatedDepth).dp)
+                .background(
+                    color = Color(0xFF972e25),
+                    shape = RoundedCornerShape(
+                        topStart = (buttonSize / 2).dp,
+                        topEnd = (buttonSize / 2).dp,
+                        bottomStart = (buttonSize / 2).dp,
+                        bottomEnd = (buttonSize / 2).dp
+                    )
+                )
+        )
+
+        // Button Top Surface (the actual pressable circular top)
+        Box(
+            modifier = Modifier
+                .offset(y = animatedButtonOffset)
+                .size(buttonSize.dp)
+                .background(
+                    color = Color(0xFFFF5757),
+                    shape = CircleShape
+                )
+                // Inner shadow/bevel effect on the top surface
+                .background(
+                    brush = Brush.radialGradient(
+                        colors = listOf(
+                            Color.White.copy(alpha = 0.3f),
+                            Color.Transparent,
+                            Color.Black.copy(alpha = 0.2f)
+                        ),
+                        radius = (buttonSize / 1.5).toFloat()
+                    ),
+                    shape = CircleShape
+                )
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onPress = {
+                            isPressed = true
+                            if(tryAwaitRelease()) isPressed = false
+                        }
+                    )
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = text,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = (buttonSize / 8).sp
+            )
+        }
+    }
+}
+
+@Composable
+fun IndustrialCylinderButtonOneState(
+    text: String,
+    modifier: Modifier = Modifier,
+    buttonSize: Int = 120,
+    cylinderDepth: Int = 20
+) {
+    var isPressed by remember { mutableStateOf(false) }
+
+    // Animation for pressing down the cylinder
+    val animatedDepth by animateIntAsState(
+        targetValue = if (isPressed) cylinderDepth / 3 else cylinderDepth,
+        animationSpec = tween(durationMillis = 150),
+        label = "depth"
+    )
+
+    val animatedButtonOffset by animateDpAsState(
+        targetValue = if (isPressed) (cylinderDepth * 2 / 3).dp else 0.dp,
+        animationSpec = tween(durationMillis = 150),
+        label = "buttonOffset"
+    )
+
+    Box(
+        modifier = modifier.size((buttonSize + cylinderDepth).dp),
+        contentAlignment = Alignment.TopCenter
+    ) {
+
+        // Cylinder Side Wall (the visible depth/body of the button)
+        Box(
+            modifier = Modifier
+                .offset(y = animatedButtonOffset)
+                .size(buttonSize.dp, (buttonSize + animatedDepth).dp)
+                .background(
+                    color = Color(0xFF972e25),
+                    shape = RoundedCornerShape(
+                        topStart = (buttonSize / 2).dp,
+                        topEnd = (buttonSize / 2).dp,
+                        bottomStart = (buttonSize / 2).dp,
+                        bottomEnd = (buttonSize / 2).dp
+                    )
+                )
+        )
+
+        // Button Top Surface (the actual pressable circular top)
+        Box(
+            modifier = Modifier
+                .offset(y = animatedButtonOffset)
+                .size(buttonSize.dp)
+                .clickable { isPressed = !isPressed }
+                .background(
+                    color = Color(0xFFFF5757),
+                    shape = CircleShape
+                )
+                // Inner shadow/bevel effect on the top surface
+                .background(
+                    brush = Brush.radialGradient(
+                        colors = listOf(
+                            Color.White.copy(alpha = 0.3f),
+                            Color.Transparent,
+                            Color.Black.copy(alpha = 0.2f)
+                        ),
+                        radius = (buttonSize / 1.5).toFloat()
+                    ),
+                    shape = CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = text,
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = (buttonSize / 8).sp
+            )
+        }
+    }
+}
+
+val cylindricalButtonCode by lazy {
+    """
+    @Composable
+    fun IndustrialCylinderButton(
+        text: String,
+        onClick: () -> Unit,
+        modifier: Modifier = Modifier,
+        buttonSize: Int = 120,
+        cylinderDepth: Int = 20
+    ) {
+        var isPressed by remember { mutableStateOf(false) }
+
+        // Animation for pressing down the cylinder
+        val animatedDepth by animateIntAsState(
+            targetValue = if (isPressed) cylinderDepth / 3 else cylinderDepth,
+            animationSpec = tween(durationMillis = 100),
+            label = "depth"
+        )
+
+        val animatedButtonOffset by animateDpAsState(
+            targetValue = if (isPressed) (cylinderDepth * 2 / 3).dp else 0.dp,
+            animationSpec = tween(durationMillis = 100),
+            label = "buttonOffset"
+        )
+
+        Box(
+            modifier = modifier.size((buttonSize + cylinderDepth).dp),
+            contentAlignment = Alignment.TopCenter
+        ) {
+
+            // Cylinder Side Wall (the visible depth/body of the button)
+            Box(
+                modifier = Modifier
+                    .offset(y = animatedButtonOffset)
+                    .size(buttonSize.dp, (buttonSize + animatedDepth).dp)
+                    .background(
+                        color = Color(0xFF972e25),
+                        shape = RoundedCornerShape(
+                            topStart = (buttonSize / 2).dp,
+                            topEnd = (buttonSize / 2).dp,
+                            bottomStart = (buttonSize / 2).dp,
+                            bottomEnd = (buttonSize / 2).dp
+                        )
+                    )
+            )
+
+            // Button Top Surface (the actual pressable circular top)
+            Box(
+                modifier = Modifier
+                    .offset(y = animatedButtonOffset)
+                    .size(buttonSize.dp)
+                    .background(
+                        color = Color(0xFFFF5757),
+                        shape = CircleShape
+                    )
+                    // Inner shadow/bevel effect on the top surface
+                    .background(
+                        brush = Brush.radialGradient(
+                            colors = listOf(
+                                Color.White.copy(alpha = 0.3f),
+                                Color.Transparent,
+                                Color.Black.copy(alpha = 0.2f)
+                            ),
+                            radius = (buttonSize / 1.5).toFloat()
+                        ),
+                        shape = CircleShape
+                    )
+                    .pointerInput(Unit) {
+                        detectTapGestures(
+                            onPress = {
+                                isPressed = true
+                                val released = tryAwaitRelease()
+                                if (released) {
+                                    onClick()
+                                }
+                                isPressed = false
+                            }
+                        )
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = text,
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = (buttonSize / 8).sp
+                )
+            }
+        }
+    }
+""".trimIndent()
+}

--- a/icc/src/main/java/com/naulian/composable/icc/cylindricalButton/CylindricalButtonsScreen.kt
+++ b/icc/src/main/java/com/naulian/composable/icc/cylindricalButton/CylindricalButtonsScreen.kt
@@ -1,0 +1,98 @@
+package com.naulian.composable.icc.cylindricalButton
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.naulian.composable.core.LocalNavController
+import com.naulian.composable.core.component.CodeBlock
+import com.naulian.composable.core.component.ComposableTopAppBar
+
+@Composable
+fun CylindricalButtonsScreen() {
+    val navController = LocalNavController.current
+
+    CylindricalButtonsScreenUI(onBack = { navController.navigateUp() })
+}
+
+@Composable
+fun CylindricalButtonsScreenUI(onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            ComposableTopAppBar(
+                title = "Depth Card",
+                onBack = onBack
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState()).padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(60.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Large emergency-style button
+                IndustrialCylinderButton(
+                    text = "Long Press",
+                    buttonSize = 140,
+                    cylinderDepth = 25
+                )
+
+                // Medium button
+                IndustrialCylinderButton(
+                    text = "Long Press",
+                    buttonSize = 100,
+                    cylinderDepth = 18
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Large emergency-style button
+                IndustrialSquareButton(
+                    text = "Long Press",
+                    buttonSize = 140,
+                    cylinderDepth = 25
+                )
+
+                // Medium button
+                IndustrialSquareButton(
+                    text = "Long Press",
+                    buttonSize = 100,
+                    cylinderDepth = 18
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Large emergency-style button
+                IndustrialCylinderButtonOneState(
+                    text = "Click",
+                    buttonSize = 140,
+                    cylinderDepth = 25
+                )
+            }
+            CodeBlock(source = cylindricalButtonCode, language = "Kotlin")
+        }
+    }
+}

--- a/scc/src/main/java/com/naulian/composable/scc/StaticCCScreenUI.kt
+++ b/scc/src/main/java/com/naulian/composable/scc/StaticCCScreenUI.kt
@@ -54,6 +54,11 @@ private val sccItemList = listOf(
         name = "Depth Card",
         contributor = "Romit Sharma",
         route = Screen.DepthCard
+    ),
+    StaticCCItem(
+        name = "Cafe Receipt",
+        contributor = "Prashant Panwar",
+        route = Screen.CafeReceipt
     )
 )
 

--- a/scc/src/main/java/com/naulian/composable/scc/cafeReceipt/WaveReceiptShape.kt
+++ b/scc/src/main/java/com/naulian/composable/scc/cafeReceipt/WaveReceiptShape.kt
@@ -1,0 +1,151 @@
+
+// WaveReceiptShape.kt
+// A Jetpack Compose Shape that draws a receipt with sinusoid (wave-like cut) edges
+// at the top and/or bottom, similar to typical printed receipt designs.
+package com.naulian.composable.scc.cafeReceipt
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.min
+
+/**
+ * WaveReceiptShape — top and bottom sinusoidal edges that START and END on a crest.
+ *
+ * amplitude: vertical distance from crest to trough
+ * cycles: number of full cycles across usable width (>= 1)
+ * cornerRadius: left/right corner radius
+ * samplingStepPx: sampling resolution in px
+ */
+class WaveReceiptShape(
+    private val amplitude: Float = 12f,
+    private val cycles: Int = 10,
+    private val cornerRadius: Float = 12f,
+    private val samplingStepPx: Int = 1
+) : Shape {
+
+    override fun createOutline(
+        size: Size,
+        layoutDirection: LayoutDirection,
+        density: Density
+    ): Outline {
+        val w = size.width
+        val h = size.height
+
+        // Guard rails
+        val cr = cornerRadius.coerceAtMost(min(w, h) / 2f)
+        val usableLeft = cr
+        val usableRight = w - cr
+        // width available for the wave (excludes corner radii)
+        val usableW = maxOf(0.0001f, usableRight - usableLeft)
+
+        val k = maxOf(1, cycles) // number of cycles
+        val wavelength = usableW / k
+
+        // Calculate total number of sample points
+        val pointsPerCycle = maxOf(3, (wavelength / samplingStepPx).toInt())
+        // total samples across the whole usable width
+        val totalPoints = pointsPerCycle * k
+
+        // sinusoid
+        fun topYAt(x: Float): Float {
+            val t = (x - usableLeft) / usableW // normalized [0..1]
+            // angle used by cosine so phase=0 at left crest and phase=2πk at right crest
+            val phase = 2.0 * PI * k * t
+            return (amplitude * (1 - cos(phase)) / 2).toFloat()
+        }
+
+        fun bottomYAt(x: Float): Float = h - topYAt(x) // top mirror
+
+        val path = Path()
+
+        // Start at top-left corner
+        path.moveTo(0f, cr)
+        if (cr > 0f) {
+            path.quadraticTo(0f, 0f, usableLeft, 0f)
+        } else {
+            path.lineTo(usableLeft, 0f)
+        }
+
+        // Top wave
+        for (i in 0..totalPoints) {
+            val x = usableLeft + i * usableW / totalPoints
+            path.lineTo(x, topYAt(x))
+        }
+
+        // Top-right corner
+        if (cr > 0f) {
+            path.quadraticTo(w, 0f, w, cr)
+        } else {
+            path.lineTo(w, cr)
+        }
+
+        // Right edge down
+        path.lineTo(w, h - cr)
+
+        // Bottom-right corner
+        if (cr > 0f) {
+            path.quadraticTo(w, h, w - cr, h)
+        } else {
+            path.lineTo(w - cr, h)
+        }
+
+        // --- Bottom wave (reverse) ---
+        for (i in totalPoints downTo 0) {
+            val x = usableLeft + i * usableW / totalPoints
+            path.lineTo(x, bottomYAt(x))
+        }
+
+        // Bottom-left corner
+        if (cr > 0f) {
+            path.quadraticTo(0f, h, 0f, h - cr)
+        } else {
+            path.lineTo(0f, h - cr)
+        }
+
+        // Close path
+        path.lineTo(0f, cr)
+        path.close()
+
+        return Outline.Generic(path)
+    }
+}
+
+@Preview
+@Composable
+fun ReceiptShapePreview() {
+    MaterialTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = Color.Gray)
+                .padding(20.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .height(600.dp)
+                    .fillMaxWidth()
+                    .align(Alignment.Center)
+                    .background(Color.White, shape = WaveReceiptShape(cycles = 20))
+            )
+        }
+    }
+}

--- a/scc/src/main/res/drawable/coffee.xml
+++ b/scc/src/main/res/drawable/coffee.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M440,720q-117,0 -198.5,-81.5T160,440v-240q0,-33 23.5,-56.5T240,120h500q58,0 99,41t41,99q0,58 -41,99t-99,41h-20v40q0,117 -81.5,198.5T440,720ZM240,320h400v-120L240,200v120ZM440,640q83,0 141.5,-58.5T640,440v-40L240,400v40q0,83 58.5,141.5T440,640ZM720,320h20q25,0 42.5,-17.5T800,260q0,-25 -17.5,-42.5T740,200h-20v120ZM160,840v-80h640v80L160,840ZM440,400Z"
+      android:fillColor="#e3e3e3"/>
+</vector>


### PR DESCRIPTION
This commit introduces new Cylindrical 3D Button composables and integrates them into the application.

Key changes include:
- Added `IndustrialSquareButton`, `IndustrialCylinderButton`, and `IndustrialCylinderButtonOneState` composables in `CylindricalButtonUI.kt`.
- Created `CylindricalButtonsScreen.kt` to showcase these new buttons.
- Updated `InteractiveCCScreenUI.kt` to include "Cylindrical 3D Buttons" in the list of interactive components.
- Modified `Screen.kt` to add a `CylindricalButtons` screen route and reordered existing screen routes for better organization.
- Updated `AppNavHost.kt` to include navigation to the new `CylindricalButtonsScreen`.

NavHost:

Added Simple Categories Comment for different screens(Static, Interactive, Animated)

[Screen_recording_20250927_212624.webm](https://github.com/user-attachments/assets/19ede330-d5f6-4737-896a-e020123a0560)
